### PR TITLE
Comment out course service from app.yml for local deployment

### DIFF
--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -1,18 +1,18 @@
 version: '2'
 services:
-  mediaservice-app:
-    image: mediaservice
-    environment:
-      - _JAVA_OPTIONS=-Xmx512m -Xms256m
-      - SPRING_PROFILES_ACTIVE=prod,swagger
-      - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true
-      - EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
-      - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://mediaservice-postgresql:5432/MediaService
-      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster
-      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_ID=internal
-      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_SECRET=internal
-      - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
+#  mediaservice-app:
+#    image: mediaservice
+#    environment:
+#      - _JAVA_OPTIONS=-Xmx512m -Xms256m
+#      - SPRING_PROFILES_ACTIVE=prod,swagger
+#      - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true
+#      - EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
+#      - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
+#      - SPRING_DATASOURCE_URL=jdbc:postgresql://mediaservice-postgresql:5432/MediaService
+#      - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster
+#      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_ID=internal
+#      - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_SECRET=internal
+#      - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
   mediaservice-postgresql:
     extends:
       file: postgresql.yml


### PR DESCRIPTION
This way you don't have to launch all services manually if you want to work on a project locally. We're removing the docker container for the service that you're going to run on your host machine through IntelliJ, which allows you to start the Backend Environment in one swoop using app.yml.