### PR TITLE
Feature/itrex 593

### DIFF
--- a/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Audio.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Audio.java
@@ -5,7 +5,6 @@ import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import java.io.Serializable;
-import java.util.Objects;
 
 /**
  * A Audio.
@@ -14,8 +13,6 @@ import java.util.Objects;
 @Table(name = "content")
 @DiscriminatorValue("2")
 public final class Audio extends Media implements Serializable {
-
-    private static final long serialVersionUID = 1L;
 
     /**
      * Length in seconds.
@@ -43,33 +40,30 @@ public final class Audio extends Media implements Serializable {
 
     /**
      * Equals method.
+     * <p>
+     * The overridden method is called because the comparison is supposed to
+     * only use the Id (primary key) here as Hibernate handles the rest.
      *
-     * @param o the other object.
-     * @return if they are equal.
+     * @param o the other object
+     * @return if they are equal
      */
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Audio)) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        Audio audio = (Audio) o;
-        return Objects.equals(getLength(), audio.getLength());
+        return super.equals(o);
     }
 
     /**
      * Hash code.
+     * <p>
+     * The overridden method is called because a constant value has to be
+     * returned here. This is because the Id is generated and set when the
+     * entity is persisted and can be null before that.
      *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), getLength());
+        return super.hashCode();
     }
 
     /**

--- a/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Content.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Content.java
@@ -11,7 +11,6 @@ import javax.persistence.InheritanceType;
 import javax.persistence.Table;
 import java.io.Serializable;
 import java.time.LocalDate;
-import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -24,230 +23,221 @@ import java.util.UUID;
 )
 public class Content implements Serializable {
 
-  /**
-   * Identifier.
-   */
-  @Id
-  @GeneratedValue
-  private UUID id;
+    /**
+     * Identifier.
+     */
+    @Id
+    @GeneratedValue
+    private UUID id;
 
-  /**
-   * Title of the Content Item.
-   */
-  @Column(name = "title")
-  private String title;
+    /**
+     * Title of the Content Item.
+     */
+    @Column(name = "title")
+    private String title;
 
-  /**
-   * Start date of the Content item.
-   */
-  @Column(name = "start_date")
-  private LocalDate startDate;
+    /**
+     * Start date of the Content item.
+     */
+    @Column(name = "start_date")
+    private LocalDate startDate;
 
-  /**
-   * End date of the Content item.
-   */
-  @Column(name = "end_date")
-  private LocalDate endDate;
+    /**
+     * End date of the Content item.
+     */
+    @Column(name = "end_date")
+    private LocalDate endDate;
 
-  /**
-   * Id of the course this item belongs to.
-   */
-  @Column(name = "course_id")
-  private UUID courseId;
+    /**
+     * Id of the course this item belongs to.
+     */
+    @Column(name = "course_id")
+    private UUID courseId;
 
-  /**
-   * Id of the chapter this item belongs to.
-   */
-  @Column(name = "chapter_id")
-  private UUID chapterId;
+    /**
+     * Id of the chapter this item belongs to.
+     */
+    @Column(name = "chapter_id")
+    private UUID chapterId;
 
-  /**
-   * Id of the uploader of this Content item.
-   */
-  @Column(name = "uploader_id")
-  private UUID uploaderId;
+    /**
+     * Id of the uploader of this Content item.
+     */
+    @Column(name = "uploader_id")
+    private UUID uploaderId;
 
-  /**
-   * Getter.
-   *
-   * @return the id.
-   */
-  public UUID getId() {
-    return id;
-  }
-
-  /**
-   * Setter. Necessary for tests. DON't use this.
-   *
-   * @param newId
-   */
-  public void setId(final UUID newId) {
-    this.id = newId;
-  }
-
-  /**
-   * Getter.
-   *
-   * @return the title.
-   */
-  public String getTitle() {
-    return title;
-  }
-
-  /**
-   * Setter.
-   *
-   * @param newTitle the title.
-   */
-  public void setTitle(final String newTitle) {
-    this.title = newTitle;
-  }
-
-  /**
-   * Getter.
-   *
-   * @return the start date.
-   */
-  public LocalDate getStartDate() {
-    return startDate;
-  }
-
-  /**
-   * Setter.
-   *
-   * @param newStartDate the start date.
-   */
-  public void setStartDate(final LocalDate newStartDate) {
-    this.startDate = newStartDate;
-  }
-
-  /**
-   * Getter.
-   *
-   * @return the end date.
-   */
-  public LocalDate getEndDate() {
-    return endDate;
-  }
-
-  /**
-   * Setter.
-   *
-   * @param newEndDate the end date.
-   */
-  public void setEndDate(final LocalDate newEndDate) {
-    this.endDate = newEndDate;
-  }
-
-  /**
-   * Getter.
-   *
-   * @return the course id.
-   */
-  public UUID getCourseId() {
-    return courseId;
-  }
-
-  /**
-   * Setter.
-   *
-   * @param newCourseId the course id.
-   */
-  public void setCourseId(final UUID newCourseId) {
-    this.courseId = newCourseId;
-  }
-
-  /**
-   * Getter.
-   *
-   * @return the chapter id.
-   */
-  public UUID getChapterId() {
-    return chapterId;
-  }
-
-  /**
-   * Setter.
-   *
-   * @param newChapterId the chapter id.
-   */
-  public void setChapterId(final UUID newChapterId) {
-    this.chapterId = newChapterId;
-  }
-
-  /**
-   * Getter.
-   *
-   * @return the uploader id
-   */
-  public UUID getUploaderId() {
-    return uploaderId;
-  }
-
-  /**
-   * Setter.
-   *
-   * @param newUploaderId the uploader id
-   */
-  public void setUploaderId(final UUID newUploaderId) {
-    this.uploaderId = newUploaderId;
-  }
-
-  /**
-   * Equals method.
-   *
-   * @param o the other object
-   * @return if they are equal
-   */
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Getter.
+     *
+     * @return the id.
+     */
+    public UUID getId() {
+        return id;
     }
-    if (!(o instanceof Content)) {
-      return false;
+
+    /**
+     * Setter. Necessary for tests. DON't use this.
+     *
+     * @param newId
+     */
+    public void setId(final UUID newId) {
+        this.id = newId;
     }
-    Content content = (Content) o;
-    return Objects.equals(getId(), content.getId())
-        && Objects.equals(getTitle(), content.getTitle())
-        && Objects.equals(getStartDate(), content.getStartDate())
-        && Objects.equals(getEndDate(), content.getEndDate())
-        && Objects.equals(getCourseId(), content.getCourseId())
-        && Objects.equals(getChapterId(), content.getChapterId())
-        && Objects.equals(getUploaderId(), content.getUploaderId());
-  }
 
-  /**
-   * Hash code method.
-   *
-   * @return the hash code
-   */
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        getId(),
-        getTitle(),
-        getStartDate(),
-        getEndDate(),
-        getCourseId(),
-        getChapterId(),
-        getUploaderId());
-  }
+    /**
+     * Getter.
+     *
+     * @return the title.
+     */
+    public String getTitle() {
+        return title;
+    }
 
-  /**
-   * To string method.
-   *
-   * @return this object as a string.
-   */
-  @Override
-  public String toString() {
-    return "Content{"
-        + "id=" + id
-        + ", title='" + title + '\''
-        + ", startDate=" + startDate
-        + ", endDate=" + endDate
-        + ", courseId=" + courseId
-        + ", chapterId=" + chapterId
-        + ", uploaderId=" + uploaderId + '}';
-  }
+    /**
+     * Setter.
+     *
+     * @param newTitle the title.
+     */
+    public void setTitle(final String newTitle) {
+        this.title = newTitle;
+    }
+
+    /**
+     * Getter.
+     *
+     * @return the start date.
+     */
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newStartDate the start date.
+     */
+    public void setStartDate(final LocalDate newStartDate) {
+        this.startDate = newStartDate;
+    }
+
+    /**
+     * Getter.
+     *
+     * @return the end date.
+     */
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newEndDate the end date.
+     */
+    public void setEndDate(final LocalDate newEndDate) {
+        this.endDate = newEndDate;
+    }
+
+    /**
+     * Getter.
+     *
+     * @return the course id.
+     */
+    public UUID getCourseId() {
+        return courseId;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newCourseId the course id.
+     */
+    public void setCourseId(final UUID newCourseId) {
+        this.courseId = newCourseId;
+    }
+
+    /**
+     * Getter.
+     *
+     * @return the chapter id.
+     */
+    public UUID getChapterId() {
+        return chapterId;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newChapterId the chapter id.
+     */
+    public void setChapterId(final UUID newChapterId) {
+        this.chapterId = newChapterId;
+    }
+
+    /**
+     * Getter.
+     *
+     * @return the uploader id
+     */
+    public UUID getUploaderId() {
+        return uploaderId;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newUploaderId the uploader id
+     */
+    public void setUploaderId(final UUID newUploaderId) {
+        this.uploaderId = newUploaderId;
+    }
+
+    /**
+     * Equals method.
+     * Only compare the Id (primary key) here as Hibernate handles the rest.
+     *
+     * @param o the other object
+     * @return if they are equal
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Content)) {
+            return false;
+        }
+        Content content = (Content) o;
+        return id != null && id.equals(content.getId());
+    }
+
+    /**
+     * Hash code.
+     * <p>
+     * Use a constant value here because the Id is generated and set when
+     * persisting and can be null before that.
+     *
+     * @return the hash code.
+     */
+    @Override
+    public int hashCode() {
+        return 13;
+    }
+
+    /**
+     * To string method.
+     *
+     * @return this object as a string.
+     */
+    @Override
+    public String toString() {
+        return "Content{"
+            + "id=" + id
+            + ", title='" + title + '\''
+            + ", startDate=" + startDate
+            + ", endDate=" + endDate
+            + ", courseId=" + courseId
+            + ", chapterId=" + chapterId
+            + ", uploaderId=" + uploaderId + '}';
+    }
 }

--- a/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Document.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Document.java
@@ -11,5 +11,5 @@ import java.io.Serializable;
 @Entity
 @Table(name = "content")
 @DiscriminatorValue("4")
-public final  class Document extends Resource implements Serializable {
+public final class Document extends Resource implements Serializable {
 }

--- a/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Image.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Image.java
@@ -5,7 +5,6 @@ import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import java.io.Serializable;
-import java.util.Objects;
 
 /**
  * A Image.
@@ -14,7 +13,6 @@ import java.util.Objects;
 @Table(name = "content")
 @DiscriminatorValue("3")
 public final class Image extends Media implements Serializable {
-    private static final long serialVersionUID = 1L;
 
     /**
      * Width in pixels.
@@ -66,36 +64,30 @@ public final class Image extends Media implements Serializable {
 
     /**
      * Equals method.
+     * <p>
+     * The overridden method is called because the comparison is supposed to
+     * only use the Id (primary key) here as Hibernate handles the rest.
      *
-     * @param o the other object.
-     * @return if they are equal.
+     * @param o the other object
+     * @return if they are equal
      */
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Image)) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        Image image = (Image) o;
-        return Objects.equals(getWidth(),
-            image.getWidth())
-            && Objects.equals(getHeight(),
-            image.getHeight());
+        return super.equals(o);
     }
 
     /**
      * Hash code.
+     * <p>
+     * The overridden method is called because a constant value has to be
+     * returned here. This is because the Id is generated and set when the
+     * entity is persisted and can be null before that.
      *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), getWidth(), getHeight());
+        return super.hashCode();
     }
 
     /**

--- a/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Resource.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Resource.java
@@ -7,76 +7,71 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Table;
-import java.util.Objects;
 
 @Entity
 @Table(name = "content")
 public abstract class Resource extends Content {
 
-  /**
-   * Mimetype of this Resource.
-   */
-  @Enumerated(EnumType.STRING)
-  @Column(name = "mime_type")
-  private MIMETYPE mimeType;
+    /**
+     * Mimetype of this Resource.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mime_type")
+    private MIMETYPE mimeType;
 
-  /**
-   * Getter.
-   *
-   * @return the mime type
-   */
-  public MIMETYPE getMimeType() {
-    return mimeType;
-  }
-
-  /**
-   * Setter.
-   *
-   * @param newMimeType the mime type.
-   */
-  public void setMimeType(final MIMETYPE newMimeType) {
-    this.mimeType = newMimeType;
-  }
-
-  /**
-   * Equals method.
-   *
-   * @param o the other object.
-   * @return if they are equal.
-   */
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
+    /**
+     * Getter.
+     *
+     * @return the mime type
+     */
+    public MIMETYPE getMimeType() {
+        return mimeType;
     }
-    if (!(o instanceof Resource)) {
-      return false;
+
+    /**
+     * Setter.
+     *
+     * @param newMimeType the mime type.
+     */
+    public void setMimeType(final MIMETYPE newMimeType) {
+        this.mimeType = newMimeType;
     }
-    if (!super.equals(o)) {
-      return false;
+
+    /**
+     * Equals method.
+     * <p>
+     * The overridden method is called because the comparison is supposed to
+     * only use the Id (primary key) here as Hibernate handles the rest.
+     *
+     * @param o the other object
+     * @return if they are equal
+     */
+    @Override
+    public boolean equals(final Object o) {
+        return super.equals(o);
     }
-    Resource resource = (Resource) o;
-    return getMimeType() == resource.getMimeType();
-  }
 
-  /**
-   * Hash code.
-   *
-   * @return the hash code.
-   */
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), getMimeType());
-  }
+    /**
+     * Hash code.
+     * <p>
+     * The overridden method is called because a constant value has to be
+     * returned here. This is because the Id is generated and set when the
+     * entity is persisted and can be null before that.
+     *
+     * @return the hash code.
+     */
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
 
-
-  /**
-   * To string method.
-   *
-   * @return this object as a string.
-   */
-  @Override
-  public String toString() {
-    return "Resource{}";
-  }
+    /**
+     * To string method.
+     *
+     * @return this object as a string.
+     */
+    @Override
+    public String toString() {
+        return "Resource{}";
+    }
 }

--- a/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Video.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/domain/written/Video.java
@@ -5,7 +5,6 @@ import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.Table;
 import java.io.Serializable;
-import java.util.Objects;
 
 /**
  * A Video.
@@ -14,8 +13,6 @@ import java.util.Objects;
 @Table(name = "content")
 @DiscriminatorValue("1")
 public final class Video extends Media implements Serializable {
-
-    private static final long serialVersionUID = 1L;
 
     /**
      * Length in seconds.
@@ -91,40 +88,30 @@ public final class Video extends Media implements Serializable {
 
     /**
      * Equals method.
+     * <p>
+     * The overridden method is called because the comparison is supposed to
+     * only use the Id (primary key) here as Hibernate handles the rest.
      *
-     * @param o the other object.
-     * @return if they are equal.
+     * @param o the other object
+     * @return if they are equal
      */
     @Override
     public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Video)) {
-            return false;
-        }
-        if (!super.equals(o)) {
-            return false;
-        }
-        Video video = (Video) o;
-        return Objects.equals(getLength(),
-            video.getLength()) && Objects.equals(getWidth(),
-            video.getWidth()) && Objects.equals(getHeight(),
-            video.getHeight());
+        return super.equals(o);
     }
 
     /**
      * Hash code.
+     * <p>
+     * The overridden method is called because a constant value has to be
+     * returned here. This is because the Id is generated and set when the
+     * entity is persisted and can be null before that.
      *
      * @return the hash code.
      */
     @Override
     public int hashCode() {
-        return Objects.hash(
-            super.hashCode(),
-            getLength(),
-            getWidth(),
-            getHeight());
+        return super.hashCode();
     }
 
     /**

--- a/src/main/java/de/uni_stuttgart/it_rex/media/service/written/VideoService.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/service/written/VideoService.java
@@ -355,24 +355,6 @@ public class VideoService {
   }
 
   /**
-   * Method applies filters to an example instance of video,
-   * which is used for running a search over all videos.
-   * <p>
-   * More filters can be added here. @s.pastuchov 20.02.21
-   *
-   * @param courseId Filter course ID.
-   * @return Example video with applied filters for search.
-   */
-  private Video applyFiltersToExample(final Optional<String> courseId) {
-    final Video video = new Video();
-      courseId.ifPresent(id -> {
-          UUID courseUuid = UUID.fromString(id);
-          video.setCourseId(courseUuid);
-      });
-      return video;
-  }
-
-  /**
    * Finds all Videos by id.
    *
    * @param ids the ids

--- a/src/main/java/de/uni_stuttgart/it_rex/media/service/written/VideoService.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/service/written/VideoService.java
@@ -355,6 +355,17 @@ public class VideoService {
   }
 
   /**
+   * Finds a Video by id.
+   *
+   * @param id the id
+   * @return the video
+   */
+  @Transactional(readOnly = true)
+  public Optional<Video> findById(final UUID id) {
+    return videoRepository.findById(id);
+  }
+
+  /**
    * Finds all Videos by id.
    *
    * @param ids the ids

--- a/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/dto/written/ByteRangeDTO.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/dto/written/ByteRangeDTO.java
@@ -1,0 +1,82 @@
+package de.uni_stuttgart.it_rex.media.web.rest.dto.written;
+
+public class ByteRangeDTO {
+
+    /**
+     * Constructor.
+     *
+     * @param theStart the start
+     * @param theEnd   the end
+     */
+    public ByteRangeDTO(final long theStart, final long theEnd) {
+        this.start = theStart;
+        this.end = theEnd;
+        this.length = calculateLength(theStart, theEnd);
+    }
+
+    /**
+     * The start of the byte range.
+     */
+    private long start;
+
+    /**
+     * The end of the byte range.
+     */
+    private long end;
+
+    /**
+     * The length of the byte range.
+     */
+    private long length;
+
+    /**
+     * Getter.
+     *
+     * @return the start of the byte range.
+     */
+    public long getStart() {
+        return start;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newStart the start of the byte range.
+     */
+    public void setStart(final long newStart) {
+        this.start = newStart;
+        this.length = calculateLength(this.start, this.end);
+    }
+
+    /**
+     * Getter.
+     *
+     * @return the end of the byte range.
+     */
+    public long getEnd() {
+        return end;
+    }
+
+    /**
+     * Setter.
+     *
+     * @param newEnd the end of the byte range.
+     */
+    public void setEnd(final long newEnd) {
+        this.end = newEnd;
+        this.length = calculateLength(this.start, this.end);
+    }
+
+    /**
+     * Getter.
+     *
+     * @return The length of the byte range.
+     */
+    public long getLength() {
+        return length;
+    }
+
+    private static long calculateLength(final long start, final long end) {
+        return end - start + 1;
+    }
+}

--- a/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/dto/written/package-info.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/dto/written/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * DTOs.
+ */
+package de.uni_stuttgart.it_rex.media.web.rest.dto.written;

--- a/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/AudioTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/AudioTest.java
@@ -1,34 +1,35 @@
 package de.uni_stuttgart.it_rex.media.domain.written;
 
+import de.uni_stuttgart.it_rex.media.util.written.AudioUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class AudioTest {
-  private static final UUID FIRST_ID = UUID.randomUUID();
-  private static final UUID SECOND_ID = UUID.randomUUID();
-  private static final Long FIRST_LENGTH = 42L;
-  private static final Long SECOND_LENGTH = 69L;
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
+    private static final Long FIRST_LENGTH = 42L;
+    private static final Long SECOND_LENGTH = 69L;
 
-  @Test
-  void equalsVerifier() {
-    Audio audio1 = new Audio();
-    audio1.setId(FIRST_ID);
-    audio1.setLength(FIRST_LENGTH);
+    @Test
+    void equalsVerifier() {
+        Audio audio1 = new Audio();
+        audio1.setId(FIRST_ID);
+        audio1.setLength(FIRST_LENGTH);
 
-    Audio audio2 = new Audio();
-    audio2.setId(SECOND_ID);
-    audio2.setLength(SECOND_LENGTH);
+        Audio audio2 = new Audio();
+        audio2.setId(SECOND_ID);
+        audio2.setLength(SECOND_LENGTH);
 
-    Audio audio3 = new Audio();
-    audio3.setId(FIRST_ID);
-    audio3.setLength(FIRST_LENGTH);
+        Audio audio3 = new Audio();
+        audio3.setId(FIRST_ID);
+        audio3.setLength(FIRST_LENGTH);
 
-    assertEquals(audio1, audio1);
-    assertEquals(audio1, audio3);
-    assertNotEquals(audio1, audio2);
-  }
+        AudioUtil.assertEquals(audio1, audio1);
+        AudioUtil.assertEquals(audio1, audio3);
+        AudioUtil.assertNotEquals(audio1, audio2);
+        assertEquals(audio1.hashCode(), audio2.hashCode());
+    }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/ContentTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/ContentTest.java
@@ -1,60 +1,61 @@
 package de.uni_stuttgart.it_rex.media.domain.written;
 
+import de.uni_stuttgart.it_rex.media.util.written.ContentUtil;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ContentTest {
-  private static final UUID ID_1 = UUID.randomUUID();
-  private static final UUID ID_2 = UUID.randomUUID();
-  private static final String TITLE_1 = "AAAAAAAAAA";
-  private static final String TITLE_2 = "BBBBBBBBBB";
-  private static final LocalDate START_DATE_1 = LocalDate.MIN.plusDays(200);
-  private static final LocalDate START_DATE_2 = LocalDate.MIN.plusDays(400);
-  private static final LocalDate END_DATE_1 = LocalDate.MAX.minusDays(200);
-  private static final LocalDate END_DATE_2 = LocalDate.MAX.minusDays(400);
-  private static final UUID COURSE_ID_1 = UUID.randomUUID();
-  private static final UUID COURSE_ID_2 = UUID.randomUUID();
-  private static final UUID CHAPTER_ID_1 = UUID.randomUUID();
-  private static final UUID CHAPTER_ID_2 = UUID.randomUUID();
-  private static final UUID UPLOADER_ID_1 = UUID.randomUUID();
-  private static final UUID UPLOADER_ID_2 = UUID.randomUUID();
+    private static final UUID ID_1 = UUID.randomUUID();
+    private static final UUID ID_2 = UUID.randomUUID();
+    private static final String TITLE_1 = "AAAAAAAAAA";
+    private static final String TITLE_2 = "BBBBBBBBBB";
+    private static final LocalDate START_DATE_1 = LocalDate.MIN.plusDays(200);
+    private static final LocalDate START_DATE_2 = LocalDate.MIN.plusDays(400);
+    private static final LocalDate END_DATE_1 = LocalDate.MAX.minusDays(200);
+    private static final LocalDate END_DATE_2 = LocalDate.MAX.minusDays(400);
+    private static final UUID COURSE_ID_1 = UUID.randomUUID();
+    private static final UUID COURSE_ID_2 = UUID.randomUUID();
+    private static final UUID CHAPTER_ID_1 = UUID.randomUUID();
+    private static final UUID CHAPTER_ID_2 = UUID.randomUUID();
+    private static final UUID UPLOADER_ID_1 = UUID.randomUUID();
+    private static final UUID UPLOADER_ID_2 = UUID.randomUUID();
 
-  @Test
-  void equals() {
-    final Content content1 = new Video();
-    content1.setId(ID_1);
-    content1.setTitle(TITLE_1);
-    content1.setStartDate(START_DATE_1);
-    content1.setEndDate(END_DATE_1);
-    content1.setCourseId(COURSE_ID_1);
-    content1.setChapterId(CHAPTER_ID_1);
-    content1.setUploaderId(UPLOADER_ID_1);
+    @Test
+    void equals() {
+        final Content content1 = new Video();
+        content1.setId(ID_1);
+        content1.setTitle(TITLE_1);
+        content1.setStartDate(START_DATE_1);
+        content1.setEndDate(END_DATE_1);
+        content1.setCourseId(COURSE_ID_1);
+        content1.setChapterId(CHAPTER_ID_1);
+        content1.setUploaderId(UPLOADER_ID_1);
 
-    final Content content2 = new Video();
-    content2.setId(ID_2);
-    content2.setTitle(TITLE_2);
-    content2.setStartDate(START_DATE_2);
-    content2.setEndDate(END_DATE_2);
-    content2.setCourseId(COURSE_ID_2);
-    content2.setChapterId(CHAPTER_ID_2);
-    content2.setUploaderId(UPLOADER_ID_2);
+        final Content content2 = new Video();
+        content2.setId(ID_2);
+        content2.setTitle(TITLE_2);
+        content2.setStartDate(START_DATE_2);
+        content2.setEndDate(END_DATE_2);
+        content2.setCourseId(COURSE_ID_2);
+        content2.setChapterId(CHAPTER_ID_2);
+        content2.setUploaderId(UPLOADER_ID_2);
 
-    final Content content3 = new Video();
-    content3.setId(ID_1);
-    content3.setTitle(TITLE_1);
-    content3.setStartDate(START_DATE_1);
-    content3.setEndDate(END_DATE_1);
-    content3.setCourseId(COURSE_ID_1);
-    content3.setChapterId(CHAPTER_ID_1);
-    content3.setUploaderId(UPLOADER_ID_1);
+        final Content content3 = new Video();
+        content3.setId(ID_1);
+        content3.setTitle(TITLE_1);
+        content3.setStartDate(START_DATE_1);
+        content3.setEndDate(END_DATE_1);
+        content3.setCourseId(COURSE_ID_1);
+        content3.setChapterId(CHAPTER_ID_1);
+        content3.setUploaderId(UPLOADER_ID_1);
 
-    assertEquals(content1, content1);
-    assertEquals(content1, content3);
-    assertNotEquals(content1, content2);
-  }
+        ContentUtil.assertEquals(content1, content1);
+        ContentUtil.assertEquals(content1, content3);
+        ContentUtil.assertNotEquals(content1, content2);
+        assertEquals(content1.hashCode(), content2.hashCode());
+    }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/DocumentTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/DocumentTest.java
@@ -1,25 +1,27 @@
 package de.uni_stuttgart.it_rex.media.domain.written;
 
+import de.uni_stuttgart.it_rex.media.util.written.DocumentUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class DocumentTest {
-  private static final UUID FIRST_ID = UUID.randomUUID();
-  private static final UUID SECOND_ID = UUID.randomUUID();
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
 
-  @Test
-  void equalsVerifier() {
-    Document document1 = new Document();
-    document1.setId(FIRST_ID);
-    Document document2 = new Document();
-    document2.setId(document1.getId());
-    assertThat(document1).isEqualTo(document2);
-    document2.setId(SECOND_ID);
-    assertThat(document1).isNotEqualTo(document2);
-    document1.setId(null);
-    assertThat(document1).isNotEqualTo(document2);
-  }
+    @Test
+    void equalsVerifier() {
+        Document document1 = new Document();
+        document1.setId(FIRST_ID);
+        Document document2 = new Document();
+        document2.setId(document1.getId());
+        DocumentUtil.equals(document1, document2);
+        document2.setId(SECOND_ID);
+        DocumentUtil.assertNotEquals(document1, document2);
+        document1.setId(null);
+        DocumentUtil.assertNotEquals(document1, document2);
+        assertEquals(document1.hashCode(), document2.hashCode());
+    }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/ImageTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/ImageTest.java
@@ -1,40 +1,40 @@
 package de.uni_stuttgart.it_rex.media.domain.written;
 
+import de.uni_stuttgart.it_rex.media.util.written.ImageUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ImageTest {
-  private static final UUID FIRST_ID = UUID.randomUUID();
-  private static final UUID SECOND_ID = UUID.randomUUID();
-  private static final Integer FIRST_WIDTH = 23423;
-  private static final Integer SECOND_WIDTH = 2999423;
-  private static final Integer FIRST_HEIGHT = 2342123;
-  private static final Integer SECOND_HEIGHT = 23345423;
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
+    private static final Integer FIRST_WIDTH = 23423;
+    private static final Integer SECOND_WIDTH = 2999423;
+    private static final Integer FIRST_HEIGHT = 2342123;
+    private static final Integer SECOND_HEIGHT = 23345423;
 
-  @Test
-  public void equalsVerifier() {
-    Image image1 = new Image();
-    image1.setId(FIRST_ID);
-    image1.setWidth(FIRST_WIDTH);
-    image1.setHeight(FIRST_HEIGHT);
+    @Test
+    public void equalsVerifier() {
+        Image image1 = new Image();
+        image1.setId(FIRST_ID);
+        image1.setWidth(FIRST_WIDTH);
+        image1.setHeight(FIRST_HEIGHT);
 
-    Image image2 = new Image();
-    image2.setId(SECOND_ID);
-    image2.setWidth(SECOND_WIDTH);
-    image2.setHeight(SECOND_HEIGHT);
+        Image image2 = new Image();
+        image2.setId(SECOND_ID);
+        image2.setWidth(SECOND_WIDTH);
+        image2.setHeight(SECOND_HEIGHT);
 
-    Image image3 = new Image();
-    image3.setId(FIRST_ID);
-    image3.setWidth(FIRST_WIDTH);
-    image3.setHeight(FIRST_HEIGHT);
+        Image image3 = new Image();
+        image3.setId(FIRST_ID);
+        image3.setWidth(FIRST_WIDTH);
+        image3.setHeight(FIRST_HEIGHT);
 
-    assertEquals(image1, image1);
-    assertEquals(image1, image3);
-    assertNotEquals(image1, image2);
-  }
+        ImageUtil.assertEquals(image1, image1);
+        ImageUtil.assertEquals(image1, image3);
+        ImageUtil.assertNotEquals(image1, image2);
+        assertEquals(image1.hashCode(), image2.hashCode());
+    }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/ResourceTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/ResourceTest.java
@@ -1,35 +1,36 @@
 package de.uni_stuttgart.it_rex.media.domain.written;
 
 import de.uni_stuttgart.it_rex.media.domain.written.enumeration.MIMETYPE;
+import de.uni_stuttgart.it_rex.media.util.written.ResourceUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 class ResourceTest {
-  private static final UUID FIRST_ID = UUID.randomUUID();
-  private static final UUID SECOND_ID = UUID.randomUUID();
-  private static final MIMETYPE MIMETYPE_1 = MIMETYPE.AUDIO_MPEG;
-  private static final MIMETYPE MIMETYPE_2 = MIMETYPE.VIDEO_MP4;
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
+    private static final MIMETYPE MIMETYPE_1 = MIMETYPE.AUDIO_MPEG;
+    private static final MIMETYPE MIMETYPE_2 = MIMETYPE.VIDEO_MP4;
 
-  @Test
-  void equalsVerifier() {
-    Resource resource1 = new Document();
-    resource1.setId(FIRST_ID);
-    resource1.setMimeType(MIMETYPE_1);
+    @Test
+    void equalsVerifier() {
+        Resource resource1 = new Document();
+        resource1.setId(FIRST_ID);
+        resource1.setMimeType(MIMETYPE_1);
 
-    Resource resource2 = new Document();
-    resource2.setId(SECOND_ID);
-    resource2.setMimeType(MIMETYPE_2);
+        Resource resource2 = new Document();
+        resource2.setId(SECOND_ID);
+        resource2.setMimeType(MIMETYPE_2);
 
-    Resource resource3 = new Document();
-    resource3.setId(FIRST_ID);
-    resource3.setMimeType(MIMETYPE_1);
+        Resource resource3 = new Document();
+        resource3.setId(FIRST_ID);
+        resource3.setMimeType(MIMETYPE_1);
 
-    assertEquals(resource1, resource1);
-    assertEquals(resource1, resource3);
-    assertNotEquals(resource1, resource2);
-  }
+        ResourceUtil.assertEquals(resource1, resource1);
+        ResourceUtil.assertEquals(resource1, resource3);
+        ResourceUtil.assertNotEquals(resource1, resource2);
+        assertEquals(resource1.hashCode(), resource2.hashCode());
+    }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/VideoTest.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/domain/written/VideoTest.java
@@ -1,44 +1,41 @@
 package de.uni_stuttgart.it_rex.media.domain.written;
 
+import de.uni_stuttgart.it_rex.media.util.written.VideoUtil;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class VideoTest {
-  private static final UUID FIRST_ID = UUID.randomUUID();
-  private static final UUID SECOND_ID = UUID.randomUUID();
-  private static final Long FIRST_LENGTH = 42L;
-  private static final Long SECOND_LENGTH = 69L;
-  private static final Integer FIRST_WIDTH = 23423;
-  private static final Integer SECOND_WIDTH = 2999423;
-  private static final Integer FIRST_HEIGHT = 2342123;
-  private static final Integer SECOND_HEIGHT = 23345423;
+    private static final UUID FIRST_ID = UUID.randomUUID();
+    private static final UUID SECOND_ID = UUID.randomUUID();
+    private static final Long FIRST_LENGTH = 42L;
+    private static final Long SECOND_LENGTH = 69L;
+    private static final Integer FIRST_WIDTH = 23423;
+    private static final Integer SECOND_WIDTH = 2999423;
+    private static final Integer FIRST_HEIGHT = 2342123;
+    private static final Integer SECOND_HEIGHT = 23345423;
 
-  @Test
-  void equalsVerifier() {
-    Video video1 = new Video();
-    video1.setId(FIRST_ID);
-    Video video2 = new Video();
-    video2.setId(video1.getId());
-    assertThat(video1).isEqualTo(video2);
+    @Test
+    void equalsVerifier() {
+        Video video1 = new Video();
+        video1.setId(FIRST_ID);
+        Video video2 = new Video();
+        video2.setId(video1.getId());
+        VideoUtil.assertEquals(video1, video2);
 
-    video1.setLength(FIRST_LENGTH);
-    video1.setWidth(FIRST_WIDTH);
-    video1.setHeight(FIRST_HEIGHT);
-    video2.setId(SECOND_ID);
-    video2.setLength(SECOND_LENGTH);
-    video1.setWidth(SECOND_WIDTH);
-    video1.setHeight(SECOND_HEIGHT);
+        video1.setLength(FIRST_LENGTH);
+        video1.setWidth(FIRST_WIDTH);
+        video1.setHeight(FIRST_HEIGHT);
+        video2.setId(SECOND_ID);
+        video2.setLength(SECOND_LENGTH);
+        video1.setWidth(SECOND_WIDTH);
+        video1.setHeight(SECOND_HEIGHT);
 
-    assertThat(video1).isNotEqualTo(video2);
-    video1.setId(null);
-    assertThat(video1).isNotEqualTo(video2);
-    assertThat(video1).isNotEqualTo(UUID.randomUUID());
-    assertThat(video1).hasSameHashCodeAs(video1);
-    assertTrue(video1.hashCode() != video2.hashCode());
-  }
+        VideoUtil.assertNotEquals(video1, video2);
+        video1.setId(null);
+        VideoUtil.assertNotEquals(video1, video2);
+        assertEquals(video1.hashCode(), video2.hashCode());
+    }
 }
-

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/AudioUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/AudioUtil.java
@@ -9,13 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class AudioUtil {
 
+    /**
+     * Checks if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
     public static boolean equals(final Audio first, final Audio second) {
         return MediaUtil.equals(first, second)
             && Objects.equals(first.getLength(), second.getLength());
     }
 
     /**
-     * Tests if two entities are equal.
+     * Asserts that two entities are equal.
      *
      * @param first
      * @param second
@@ -25,7 +31,7 @@ public final class AudioUtil {
     }
 
     /**
-     * Tests if two entities are not equal.
+     * Asserts that two entities are not equal.
      *
      * @param first
      * @param second

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/AudioUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/AudioUtil.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AudioUtil {
+public final class AudioUtil {
 
     public static boolean equals(final Audio first, final Audio second) {
         return MediaUtil.equals(first, second)

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/AudioUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/AudioUtil.java
@@ -1,0 +1,36 @@
+package de.uni_stuttgart.it_rex.media.util.written;
+
+import de.uni_stuttgart.it_rex.media.domain.written.Audio;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AudioUtil {
+
+    public static boolean equals(final Audio first, final Audio second) {
+        return MediaUtil.equals(first, second)
+            && Objects.equals(first.getLength(), second.getLength());
+    }
+
+    /**
+     * Tests if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertEquals(final Audio first, final Audio second) {
+        assertTrue(equals(first, second));
+    }
+
+    /**
+     * Tests if two entities are not equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertNotEquals(final Audio first, final Audio second) {
+        assertFalse(equals(first, second));
+    }
+}

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ContentUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ContentUtil.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ContentUtil {
+public final class ContentUtil {
 
     /**
      * Tests if two entities are equal.

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ContentUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ContentUtil.java
@@ -1,0 +1,47 @@
+package de.uni_stuttgart.it_rex.media.util.written;
+
+import de.uni_stuttgart.it_rex.media.domain.written.Content;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ContentUtil {
+
+    /**
+     * Tests if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static boolean equals(final Content first, final Content second) {
+        return Objects.equals(first.getId(), second.getId())
+            && Objects.equals(first.getTitle(), second.getTitle())
+            && Objects.equals(first.getStartDate(), second.getStartDate())
+            && Objects.equals(first.getEndDate(), second.getEndDate())
+            && Objects.equals(first.getCourseId(), second.getCourseId())
+            && Objects.equals(first.getChapterId(), second.getChapterId())
+            && Objects.equals(first.getUploaderId(), second.getUploaderId());
+    }
+
+    /**
+     * Tests if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertEquals(final Content first, final Content second) {
+        assertTrue(equals(first, second));
+    }
+
+    /**
+     * Tests if two entities are not equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertNotEquals(final Content first, final Content second) {
+        assertFalse(equals(first, second));
+    }
+}

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/DocumentUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/DocumentUtil.java
@@ -7,12 +7,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class DocumentUtil {
 
+    /**
+     * Checks if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
     public static boolean equals(final Document first, final Document second) {
         return ResourceUtil.equals(first, second);
     }
 
     /**
-     * Tests if two entities are equal.
+     * Asserts that two entities are equal.
      *
      * @param first
      * @param second
@@ -22,7 +28,7 @@ public final class DocumentUtil {
     }
 
     /**
-     * Tests if two entities are not equal.
+     * Asserts that two entities are not equal.
      *
      * @param first
      * @param second

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/DocumentUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/DocumentUtil.java
@@ -5,7 +5,7 @@ import de.uni_stuttgart.it_rex.media.domain.written.Document;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class DocumentUtil {
+public final class DocumentUtil {
 
     public static boolean equals(final Document first, final Document second) {
         return ResourceUtil.equals(first, second);

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/DocumentUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/DocumentUtil.java
@@ -1,0 +1,33 @@
+package de.uni_stuttgart.it_rex.media.util.written;
+
+import de.uni_stuttgart.it_rex.media.domain.written.Document;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DocumentUtil {
+
+    public static boolean equals(final Document first, final Document second) {
+        return ResourceUtil.equals(first, second);
+    }
+
+    /**
+     * Tests if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertEquals(final Document first, final Document second) {
+        assertTrue(equals(first, second));
+    }
+
+    /**
+     * Tests if two entities are not equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertNotEquals(final Document first, final Document second) {
+        assertFalse(equals(first, second));
+    }
+}

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/EnumUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/EnumUtil.java
@@ -2,7 +2,7 @@ package de.uni_stuttgart.it_rex.media.util.written;
 
 import de.uni_stuttgart.it_rex.media.domain.written.enumeration.MIMETYPE;
 
-public class EnumUtil {
+public final class EnumUtil {
   /**
    * Generates a random mimetype.
    *

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ImageUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ImageUtil.java
@@ -1,0 +1,37 @@
+package de.uni_stuttgart.it_rex.media.util.written;
+
+import de.uni_stuttgart.it_rex.media.domain.written.Image;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ImageUtil {
+
+    public static boolean equals(final Image first, final Image second) {
+        return MediaUtil.equals(first, second)
+            && Objects.equals(first.getHeight(), second.getHeight())
+            && Objects.equals(first.getWidth(), second.getWidth());
+    }
+
+    /**
+     * Tests if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertEquals(final Image first, final Image second) {
+        assertTrue(equals(first, second));
+    }
+
+    /**
+     * Tests if two entities are not equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertNotEquals(final Image first, final Image second) {
+        assertFalse(equals(first, second));
+    }
+}

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ImageUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ImageUtil.java
@@ -9,6 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ImageUtil {
 
+    /**
+     * Checks if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
     public static boolean equals(final Image first, final Image second) {
         return MediaUtil.equals(first, second)
             && Objects.equals(first.getHeight(), second.getHeight())
@@ -16,7 +22,7 @@ public final class ImageUtil {
     }
 
     /**
-     * Tests if two entities are equal.
+     * Asserts that two entities are equal.
      *
      * @param first
      * @param second
@@ -26,7 +32,7 @@ public final class ImageUtil {
     }
 
     /**
-     * Tests if two entities are not equal.
+     * Asserts that two entities are not equal.
      *
      * @param first
      * @param second

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ImageUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ImageUtil.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ImageUtil {
+public final class ImageUtil {
 
     public static boolean equals(final Image first, final Image second) {
         return MediaUtil.equals(first, second)

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/MediaUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/MediaUtil.java
@@ -5,7 +5,7 @@ import de.uni_stuttgart.it_rex.media.domain.written.Media;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class MediaUtil {
+public final class MediaUtil {
 
     public static boolean equals(final Media first, final Media second) {
         return ResourceUtil.equals(first, second);

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/MediaUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/MediaUtil.java
@@ -7,12 +7,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class MediaUtil {
 
+    /**
+     * Checks if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
     public static boolean equals(final Media first, final Media second) {
         return ResourceUtil.equals(first, second);
     }
 
     /**
-     * Tests if two entities are equal.
+     * Asserts that two entities are equal.
      *
      * @param first
      * @param second
@@ -22,7 +28,7 @@ public final class MediaUtil {
     }
 
     /**
-     * Tests if two entities are not equal.
+     * Asserts that two entities are not equal.
      *
      * @param first
      * @param second

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/MediaUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/MediaUtil.java
@@ -1,0 +1,33 @@
+package de.uni_stuttgart.it_rex.media.util.written;
+
+import de.uni_stuttgart.it_rex.media.domain.written.Media;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MediaUtil {
+
+    public static boolean equals(final Media first, final Media second) {
+        return ResourceUtil.equals(first, second);
+    }
+
+    /**
+     * Tests if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertEquals(final Media first, final Media second) {
+        assertTrue(equals(first, second));
+    }
+
+    /**
+     * Tests if two entities are not equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertNotEquals(final Media first, final Media second) {
+        assertFalse(equals(first, second));
+    }
+}

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ResourceUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ResourceUtil.java
@@ -1,0 +1,36 @@
+package de.uni_stuttgart.it_rex.media.util.written;
+
+import de.uni_stuttgart.it_rex.media.domain.written.Resource;
+
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ResourceUtil {
+
+    public static boolean equals(final Resource first, final Resource second) {
+        return ContentUtil.equals(first, second)
+            && Objects.equals(first.getMimeType(), second.getMimeType());
+    }
+
+    /**
+     * Tests if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertEquals(final Resource first, final Resource second) {
+        assertTrue(equals(first, second));
+    }
+
+    /**
+     * Tests if two entities are not equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertNotEquals(final Resource first, final Resource second) {
+        assertFalse(equals(first, second));
+    }
+}

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ResourceUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ResourceUtil.java
@@ -9,13 +9,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public final class ResourceUtil {
 
+    /**
+     * Checks if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
     public static boolean equals(final Resource first, final Resource second) {
         return ContentUtil.equals(first, second)
             && Objects.equals(first.getMimeType(), second.getMimeType());
     }
 
     /**
-     * Tests if two entities are equal.
+     * Asserts that two entities are equal.
      *
      * @param first
      * @param second
@@ -25,7 +31,7 @@ public final class ResourceUtil {
     }
 
     /**
-     * Tests if two entities are not equal.
+     * Asserts that two entities are not equal.
      *
      * @param first
      * @param second

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ResourceUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/ResourceUtil.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ResourceUtil {
+public final class ResourceUtil {
 
     public static boolean equals(final Resource first, final Resource second) {
         return ContentUtil.equals(first, second)

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/VideoUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/VideoUtil.java
@@ -4,59 +4,69 @@ import de.uni_stuttgart.it_rex.media.domain.written.Video;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class VideoUtil {
-  /**
-   * Creates a random entity.
-   *
-   * @return the entity
-   */
-  public static Video createVideo() {
-    final Video video = new Video();
-    video.setTitle(StringUtil.generateRandomString(10, 50));
-    video.setStartDate(LocalDate.now().minusDays(NumbersUtil.generateRandomInteger(20, 200)));
-    video.setEndDate(LocalDate.now().plusDays(NumbersUtil.generateRandomInteger(20, 200)));
-    video.setCourseId(UUID.randomUUID());
-    video.setChapterId(UUID.randomUUID());
-    video.setUploaderId(UUID.randomUUID());
-    video.setMimeType(EnumUtil.generateRandomMimeType());
-    video.setWidth(NumbersUtil.generateRandomInteger(10, 1080));
-    video.setHeight(NumbersUtil.generateRandomInteger(10, 1920));
-    video.setLength(NumbersUtil.generateRandomLong(10, 9999));
-    return video;
-  }
+    /**
+     * Creates a random entity.
+     *
+     * @return the entity
+     */
+    public static Video createVideo() {
+        final Video video = new Video();
+        video.setTitle(StringUtil.generateRandomString(10, 50));
+        video.setStartDate(LocalDate.now().minusDays(NumbersUtil.generateRandomInteger(20, 200)));
+        video.setEndDate(LocalDate.now().plusDays(NumbersUtil.generateRandomInteger(20, 200)));
+        video.setCourseId(UUID.randomUUID());
+        video.setChapterId(UUID.randomUUID());
+        video.setUploaderId(UUID.randomUUID());
+        video.setMimeType(EnumUtil.generateRandomMimeType());
+        video.setWidth(NumbersUtil.generateRandomInteger(10, 1080));
+        video.setHeight(NumbersUtil.generateRandomInteger(10, 1920));
+        video.setLength(NumbersUtil.generateRandomLong(10, 9999));
+        return video;
+    }
 
-  /**
-   * Creates a List of random entities.
-   *
-   * @param number the length of the list
-   * @return the DTOs
-   */
-  public static List<Video> createVideos(final int number) {
-    return IntStream.range(0, number).mapToObj(i -> createVideo()).collect(Collectors.toList());
-  }
+    /**
+     * Creates a List of random entities.
+     *
+     * @param number the length of the list
+     * @return the DTOs
+     */
+    public static List<Video> createVideos(final int number) {
+        return IntStream.range(0, number).mapToObj(i -> createVideo()).collect(Collectors.toList());
+    }
 
-  /**
-   * Tests if two entities are equal but ignores their id.
-   *
-   * @param first
-   * @param second
-   */
-  public static void equals(final Video first, final Video second) {
-    assertEquals(first.getTitle(), first.getTitle());
-    assertEquals(first.getStartDate(), first.getStartDate());
-    assertEquals(first.getEndDate(), first.getEndDate());
-    assertEquals(first.getCourseId(), first.getCourseId());
-    assertEquals(first.getChapterId(), first.getChapterId());
-    assertEquals(first.getUploaderId(), first.getUploaderId());
-    assertEquals(first.getMimeType(), first.getMimeType());
-    assertEquals(first.getWidth(), first.getWidth());
-    assertEquals(first.getHeight(), first.getHeight());
-    assertEquals(first.getLength(), first.getLength());
-  }
+    public static boolean equals(final Video first, final Video second) {
+        return MediaUtil.equals(first, second)
+            && Objects.equals(first.getLength(), second.getLength())
+            && Objects.equals(first.getHeight(), second.getHeight())
+            && Objects.equals(first.getWidth(), second.getWidth());
+    }
+
+    /**
+     * Tests if two entities are equal but ignores their id.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertEquals(final Video first, final Video second) {
+        assertTrue(equals(first, second));
+    }
+
+    /**
+     * Tests if two entities are not equal.
+     *
+     * @param first
+     * @param second
+     */
+    public static void assertNotEquals(final Video first, final Video second) {
+        assertFalse(equals(first, second));
+    }
 }

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/VideoUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/VideoUtil.java
@@ -12,7 +12,7 @@ import java.util.stream.IntStream;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class VideoUtil {
+public final class VideoUtil {
     /**
      * Creates a random entity.
      *

--- a/src/test/java/de/uni_stuttgart/it_rex/media/util/written/VideoUtil.java
+++ b/src/test/java/de/uni_stuttgart/it_rex/media/util/written/VideoUtil.java
@@ -43,6 +43,12 @@ public final class VideoUtil {
         return IntStream.range(0, number).mapToObj(i -> createVideo()).collect(Collectors.toList());
     }
 
+    /**
+     * Checks if two entities are equal.
+     *
+     * @param first
+     * @param second
+     */
     public static boolean equals(final Video first, final Video second) {
         return MediaUtil.equals(first, second)
             && Objects.equals(first.getLength(), second.getLength())
@@ -51,7 +57,7 @@ public final class VideoUtil {
     }
 
     /**
-     * Tests if two entities are equal but ignores their id.
+     * Asserts that two entities are equal but ignores their id.
      *
      * @param first
      * @param second
@@ -61,7 +67,7 @@ public final class VideoUtil {
     }
 
     /**
-     * Tests if two entities are not equal.
+     * Asserts that two entities are not equal.
      *
      * @param first
      * @param second


### PR DESCRIPTION
Das gleich wie https://github.com/IT-REX-Platform/CourseService/pull/41. 
Die Subklassen von Content überschreiben equals und hashcode nur weil sonar lint sich sonst beschwert.   
Hab noch ne Methode entfernt die nicht gebraucht wird.

Video Dateien bekommen jetzt beim Download den korrekten Namen.