### PR TITLE
ITREX-602

### DIFF
--- a/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/written/VideoResource.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/written/VideoResource.java
@@ -159,15 +159,15 @@ public class VideoResource {
   }
 
   /**
-   * {@code GET  /videos} : get all the videos of a Course.
+   * {@code GET  /videos/course/{courseId:.+}} : get all the videos of a Course.
    *
    * @param courseId Course ID.
    * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the
    * list of videos in body.
    */
-  @GetMapping("/videos/course")
+  @GetMapping("/videos/course/{courseId:.+}")
   public List<Video> findAllVideosOfACourse(
-      @RequestParam("course_id") final UUID courseId) {
+      @PathVariable final UUID courseId) {
     LOGGER.debug("REST request to get all Videos");
     return videoService.findAllVideosOfACourse(courseId);
   }
@@ -259,14 +259,14 @@ public class VideoResource {
   }
 
   /**
-   * {@code GET  /videos} : get all the videos with ids.
+   * {@code GET  /videos/} : get all the videos with ids.
    *
-   * @param videoIds Video IDs.
-   * @return the map of videos in body.
+   * @param videoIds Video IDs as comma separated list.
+   * @return the map of videos in the body.
    */
   @GetMapping("/videos")
   public Map<UUID, Video> findAllWithIds(
-      @RequestBody final List<UUID> videoIds) {
+      @RequestParam final List<UUID> videoIds) {
     LOGGER.info("REST request to get all videos with the ids: {}", videoIds);
     final List<Video> videos = videoService.findAllWithIds(videoIds);
     return videos.stream().collect(

--- a/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/written/VideoResource.java
+++ b/src/main/java/de/uni_stuttgart/it_rex/media/web/rest/written/VideoResource.java
@@ -40,8 +40,10 @@ import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.hibernate.id.IdentifierGenerator.ENTITY_NAME;
 
@@ -163,7 +165,7 @@ public class VideoResource {
    * @return the {@link ResponseEntity} with status {@code 200 (OK)} and the
    * list of videos in body.
    */
-  @GetMapping("/videos")
+  @GetMapping("/videos/course")
   public List<Video> findAllVideosOfACourse(
       @RequestParam("course_id") final UUID courseId) {
     LOGGER.debug("REST request to get all Videos");
@@ -191,7 +193,7 @@ public class VideoResource {
    * @param headers The request headers.
    * @return A ResponseEntity to stream the file to the client.
    */
-  @GetMapping("/videos/{id:.+}")
+  @GetMapping("/videos/download/{id:.+}")
   public ResponseEntity<Resource> downloadVideo(
     @PathVariable final UUID id,
     @RequestHeader final HttpHeaders headers) {
@@ -250,10 +252,25 @@ public class VideoResource {
 
     final Video result = videoService.patch(video);
     return ResponseEntity.ok()
-      .headers(HeaderUtil
-        .createEntityUpdateAlert(this.getApplicationName(),
-          true, ENTITY_NAME, result.getId().toString()))
-      .body(result);
+        .headers(HeaderUtil
+            .createEntityUpdateAlert(this.getApplicationName(),
+                true, ENTITY_NAME, result.getId().toString()))
+        .body(result);
+  }
+
+  /**
+   * {@code GET  /videos} : get all the videos with ids.
+   *
+   * @param videoIds Video IDs.
+   * @return the map of videos in body.
+   */
+  @GetMapping("/videos")
+  public Map<UUID, Video> findAllWithIds(
+      @RequestBody final List<UUID> videoIds) {
+    LOGGER.info("REST request to get all videos with the ids: {}", videoIds);
+    final List<Video> videos = videoService.findAllWithIds(videoIds);
+    return videos.stream().collect(
+        Collectors.toMap(Video::getId, video -> video));
   }
 
   /**


### PR DESCRIPTION
Changed videopool endpoint from /videos to videos/course
Changed download endpoint form /videos to videos/download
Added an endpoint that receives a JSON list of UUIDs and returns a list of Video entities that have those ids as primary keys 

I had to change those endpoints because they led to conflicts with the new one. This is a breaking change. 